### PR TITLE
Add `cookie_template` to `Store` trait

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -18,6 +18,7 @@ pub trait Store : cookies::KeyProvider {
     type Session: Encodable + Decodable + Default + Debug;
 
     fn timeout() -> Duration { Duration::minutes(60) }
+    fn cookie_template() -> Cookie { Cookie::new(COOKIE_KEY.into(), "".into()) }
 }
 
 // Plugin boilerplate
@@ -50,8 +51,9 @@ where T: 'static + Any + Encodable + Decodable + Default + Debug,
             };
 
             let jar = response.cookies_mut().encrypted();
-            let mut cookie = Cookie::new(COOKIE_KEY.into(), encoded);
+            let mut cookie = D::cookie_template();
             cookie.httponly = true;
+            cookie.value = encoded;
             jar.add(cookie);
         });
 


### PR DESCRIPTION
I ran into some strange (from my point of view) browser behavior where I
was getting __SESSION cookies set for path="/" _and_ path="/tumblr",
presumably because I was setting a session cookie in my oauth callback, which was located as /tumblr/callback.
I would prefer to be able to set the path explicitly upon creation of
the cookie, to control this browser behavior.

I am also open to setting the default for the trait to `None`, if you
would prefer that, I can easily override it in my app.
